### PR TITLE
Use correct chart location

### DIFF
--- a/releases/lab/podinfo.yaml
+++ b/releases/lab/podinfo.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   releaseName: podinfo-prod
   chart:
-    git: git@github.com:fluxcd/helm-operator-get-started
+    git: git@github.com:abelino/k8s-homelab-flux
     path: charts/podinfo
     ref: master
   values:


### PR DESCRIPTION
While creating initial chart from `fluxcd`'s getting stated guide, I overlooked updating the chart location