### PR TITLE
Pin chart version to v9.13.0

### DIFF
--- a/releases/traefik.yaml
+++ b/releases/traefik.yaml
@@ -11,7 +11,7 @@ spec:
   chart:
     git: https://github.com/traefik/traefik-helm-chart.git
     path: traefik/
-    ref: master
+    ref: v9.13.0
   values:
     image:
       repository: traefik


### PR DESCRIPTION
Latest version of the traefik-helm-chart is incompatible w/ traefik version prior to v2.4. Pinning the chart version to v9.13.0 fixes the issue short term.